### PR TITLE
Fix raw_input() for python3.

### DIFF
--- a/dosocs2/dosocs2.py
+++ b/dosocs2/dosocs2.py
@@ -260,7 +260,10 @@ def main(sysargv=None):
         errmsg('all existing data will be deleted!')
         errmsg('type the word "YES" (all uppercase) to commit.')
         if not argv['--no-confirm']:
-            answer = raw_input()
+            if sys.version[0] > 2:
+                answer = input()
+            else:
+                answer = raw_input()
             if answer != 'YES':
                 errmsg('canceling operation.')
                 return 1


### PR DESCRIPTION
Change raw_input() to input() when using python3.

Signed-off-by: Zheng Ruoqin <zhengrq.fnst@cn.fujitsu.com>